### PR TITLE
chore(ci): group GitHub Actions major upgrades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -131,7 +131,7 @@ jobs:
 
       # ⬇️ upload uniquement les vrais bundles
       - name: Upload binaries only
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bundle-${{ matrix.build_id }}
           path: |
@@ -152,7 +152,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary
- group the Dependabot GitHub Actions major bumps from #2, #3, #4, and #5
- update checkout to v6, setup-node to v6, upload-artifact to v7, and download-artifact to v8 in the release workflow
- keep the workflow behavior otherwise unchanged

## Validation
- reviewed the upstream release notes for each action
- confirmed this workflow runs only on GitHub-hosted runners, so the newer runner requirements are acceptable here
- confirmed setup-node still uses explicit npm caching and artifact upload/download usage still matches the zipped multi-file flow in this workflow

## Limitation
- this workflow only runs on pushed version tags (), so there is no local or PR-time execution path to fully validate it before merge

Closes #2
Closes #3
Closes #4
Closes #5