### PR TITLE
chore(deps): upgrade thiserror to v2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5975,7 +5975,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "unicode-normalization",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 rusqlite = { version = "0.31", features = ["bundled"] }
 directories = "5"
 rfd = "0.15"


### PR DESCRIPTION
Summary
- upgrade thiserror from 1.0.69 to 2.0.18 in src-tauri
- no Rust code changes were required because the existing derive(Error) usage remains compatible

Validation
- cargo check in src-tauri: passed

Supersedes #14