### PR TITLE
fix(editor): anchor gutter toolbar to editor left edge for indented blocks

### DIFF
--- a/src/domains/editor/composables/useEditorBlockGutterController.test.ts
+++ b/src/domains/editor/composables/useEditorBlockGutterController.test.ts
@@ -25,11 +25,16 @@ function createEditorHarness() {
   })
 
   const selection = createSelection('heading', { level: 2 }, 'Title')
+  const editorDom = document.createElement('div')
+  Object.defineProperty(editorDom, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({ left: 80, top: 50, width: 320, height: 600, right: 400, bottom: 650 })
+  })
   const editor = {
     isFocused: true,
     state: { selection },
     view: {
-      dom: document.createElement('div'),
+      dom: editorDom,
       hasFocus: () => true,
       nodeDOM: () => blockEl
     }
@@ -118,6 +123,29 @@ describe('useEditorBlockGutterController', () => {
       nodeType: 'bulletList',
       text: 'Item'
     })
+  })
+
+  it('anchors the toolbar to the editor left edge even for indented blocks', () => {
+    const harness = createEditorHarness()
+
+    // Simulate an indented block whose left edge is 40px right of the editor's left
+    const indentedBlockEl = document.createElement('div')
+    Object.defineProperty(indentedBlockEl, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 120, top: 120, width: 280, height: 24, right: 400, bottom: 144 })
+    })
+    harness.editor.view.nodeDOM = () => indentedBlockEl
+
+    const controller = useEditorBlockGutterController({
+      getEditor: () => harness.editor,
+      holder: harness.holder,
+      titleEditorFocused: harness.titleEditorFocused
+    })
+
+    controller.syncSelectionTarget()
+
+    // left must use editor.view.dom.left (80), not the indented block's left (120)
+    expect(controller.anchorRect.value?.left).toBe(64) // 80 - 20 + 4
   })
 
   it('pins a stable menu target while the live selection keeps moving', () => {

--- a/src/domains/editor/composables/useEditorBlockGutterController.ts
+++ b/src/domains/editor/composables/useEditorBlockGutterController.ts
@@ -81,8 +81,9 @@ export function useEditorBlockGutterController(options: {
 
     const holderRect = holder.getBoundingClientRect()
     const blockRect = blockElement.getBoundingClientRect()
+    const editorRect = editor.view.dom.getBoundingClientRect()
     anchorRect.value = {
-      left: blockRect.left - holderRect.left + holder.scrollLeft,
+      left: editorRect.left - holderRect.left + holder.scrollLeft,
       top: blockRect.top - holderRect.top + holder.scrollTop + blockRect.height / 2,
       width: blockRect.width,
       height: blockRect.height


### PR DESCRIPTION
## Summary

- The gutter toolbar was positioned using the block element's own left edge, which shifted it rightward for indented content (list items, callouts, etc.), causing it to overlap the text
- Fixed by using `editor.view.dom.getBoundingClientRect().left` instead — this always reflects the consistent left boundary of the editor content area regardless of block indentation
- Added a unit test that explicitly covers the indented block case

## Test plan

- [ ] Open a note with a bulleted or numbered list, place the cursor in a list item — toolbar should appear flush-left with the rest of the content, not overlapping text
- [ ] Same check for heading blocks (non-indented) — toolbar position should be unchanged
- [ ] `useEditorBlockGutterController` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)