### PR TITLE
test: add unit tests for echoes, explorerTreeUtils, propertyTypes, frontmatter

### DIFF
--- a/src/domains/echoes/lib/echoes.test.ts
+++ b/src/domains/echoes/lib/echoes.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { toEchoesPack } from './echoes'
+import type { EchoesPackDto } from './echoes'
+
+describe('toEchoesPack', () => {
+  it('maps snake_case DTO fields to camelCase', () => {
+    const dto: EchoesPackDto = {
+      anchor_path: '/vault/note.md',
+      generated_at_ms: 1700000000000,
+      items: [
+        {
+          path: '/vault/other.md',
+          title: 'Other',
+          reason_label: 'Direct link',
+          reason_labels: ['Direct link'],
+          score: 0.95,
+          signal_sources: ['direct']
+        }
+      ]
+    }
+
+    const result = toEchoesPack(dto)
+
+    expect(result.anchorPath).toBe('/vault/note.md')
+    expect(result.generatedAtMs).toBe(1700000000000)
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]).toEqual({
+      path: '/vault/other.md',
+      title: 'Other',
+      reasonLabel: 'Direct link',
+      reasonLabels: ['Direct link'],
+      score: 0.95,
+      signalSources: ['direct']
+    })
+  })
+
+  it('handles an empty items array', () => {
+    const dto: EchoesPackDto = {
+      anchor_path: '/vault/note.md',
+      generated_at_ms: 0,
+      items: []
+    }
+
+    const result = toEchoesPack(dto)
+
+    expect(result.anchorPath).toBe('/vault/note.md')
+    expect(result.items).toEqual([])
+  })
+
+  it('maps multiple signal sources per item', () => {
+    const dto: EchoesPackDto = {
+      anchor_path: '/a.md',
+      generated_at_ms: 1,
+      items: [
+        {
+          path: '/b.md',
+          title: 'B',
+          reason_label: 'Backlink',
+          reason_labels: ['Backlink', 'Semantic'],
+          score: 0.8,
+          signal_sources: ['backlink', 'semantic']
+        }
+      ]
+    }
+
+    const result = toEchoesPack(dto)
+
+    expect(result.items[0].signalSources).toEqual(['backlink', 'semantic'])
+    expect(result.items[0].reasonLabels).toEqual(['Backlink', 'Semantic'])
+  })
+
+  it('preserves score value exactly', () => {
+    const dto: EchoesPackDto = {
+      anchor_path: '/a.md',
+      generated_at_ms: 1,
+      items: [
+        {
+          path: '/b.md',
+          title: 'B',
+          reason_label: 'Recent',
+          reason_labels: ['Recent'],
+          score: 0.123456789,
+          signal_sources: ['recent']
+        }
+      ]
+    }
+
+    expect(toEchoesPack(dto).items[0].score).toBe(0.123456789)
+  })
+
+  it('does not mutate the source DTO', () => {
+    const dto: EchoesPackDto = {
+      anchor_path: '/a.md',
+      generated_at_ms: 1,
+      items: [
+        {
+          path: '/b.md',
+          title: 'B',
+          reason_label: 'Direct link',
+          reason_labels: ['Direct link'],
+          score: 1,
+          signal_sources: ['direct']
+        }
+      ]
+    }
+    const originalItems = dto.items
+
+    toEchoesPack(dto)
+
+    expect(dto.items).toBe(originalItems)
+  })
+})

--- a/src/domains/editor/lib/frontmatter.test.ts
+++ b/src/domains/editor/lib/frontmatter.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+import { composeMarkdownDocument, parseFrontmatter, serializeFrontmatter } from './frontmatter'
+import type { FrontmatterField } from './frontmatter'
+
+const EMPTY_SCHEMA = {}
+
+// ---------------------------------------------------------------------------
+// parseFrontmatter
+// ---------------------------------------------------------------------------
+
+describe('parseFrontmatter', () => {
+  it('returns hasFrontmatter:false for plain markdown', () => {
+    const result = parseFrontmatter('# Hello\n\nworld', EMPTY_SCHEMA)
+    expect(result.hasFrontmatter).toBe(false)
+    expect(result.fields).toEqual([])
+    expect(result.body).toBe('# Hello\n\nworld')
+  })
+
+  it('parses a simple scalar field', () => {
+    const md = '---\ntitle: My Note\n---\nbody'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.hasFrontmatter).toBe(true)
+    expect(result.fields).toHaveLength(1)
+    expect(result.fields[0]).toMatchObject({ key: 'title', value: 'My Note', type: 'text' })
+    expect(result.body).toBe('body')
+  })
+
+  it('parses boolean scalars', () => {
+    const md = '---\ndraft: true\npublished: false\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.fields.find((f) => f.key === 'draft')?.value).toBe(true)
+    expect(result.fields.find((f) => f.key === 'published')?.value).toBe(false)
+  })
+
+  it('parses numeric scalars (integer and float)', () => {
+    const md = '---\nrating: 5\npriority: -2\nweight: 3.14\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.fields.find((f) => f.key === 'rating')?.value).toBe(5)
+    expect(result.fields.find((f) => f.key === 'priority')?.value).toBe(-2)
+    expect(result.fields.find((f) => f.key === 'weight')?.value).toBe(3.14)
+  })
+
+  it('parses an inline list', () => {
+    const md = '---\ntags: [alpha, beta, gamma]\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    const field = result.fields.find((f) => f.key === 'tags')
+    expect(field?.value).toEqual(['alpha', 'beta', 'gamma'])
+    expect(field?.styleHint).toBe('inline-list')
+  })
+
+  it('parses a block list', () => {
+    const md = '---\nrefs:\n  - a.md\n  - b.md\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    const field = result.fields.find((f) => f.key === 'refs')
+    expect(field?.value).toEqual(['a.md', 'b.md'])
+    expect(field?.styleHint).toBe('block-list')
+  })
+
+  it('parses a literal block scalar', () => {
+    const md = '---\nnotes: |\n  line one\n  line two\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    const field = result.fields.find((f) => f.key === 'notes')
+    expect(field?.styleHint).toBe('literal-block')
+    expect(String(field?.value)).toContain('line one')
+  })
+
+  it('detects duplicate key errors', () => {
+    const md = '---\ntitle: A\ntitle: B\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.parseErrors.some((e) => /duplicate/i.test(e.message))).toBe(true)
+  })
+
+  it('reports an error for unexpected indentation', () => {
+    const md = '---\n  indented: value\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.parseErrors.some((e) => /indentation/i.test(e.message))).toBe(true)
+  })
+
+  it('reports an error for invalid property syntax', () => {
+    const md = '---\njust-a-line-without-colon\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.parseErrors.some((e) => /invalid/i.test(e.message))).toBe(true)
+  })
+
+  it('prefers schema type over inferred type', () => {
+    const schema = { score: 'text' as const }
+    const md = '---\nscore: 42\n---\n'
+    const result = parseFrontmatter(md, schema)
+    expect(result.fields[0].type).toBe('text')
+  })
+
+  it('normalizes Windows CRLF line endings', () => {
+    const md = '---\r\ntitle: Hello\r\n---\r\nbody'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.hasFrontmatter).toBe(true)
+    expect(result.fields[0].value).toBe('Hello')
+  })
+
+  it('skips comment lines and blank lines inside frontmatter', () => {
+    const md = '---\n# a comment\n\ntitle: Real\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.fields).toHaveLength(1)
+    expect(result.fields[0].key).toBe('title')
+  })
+
+  it('assigns ascending order values to fields', () => {
+    const md = '---\na: 1\nb: 2\nc: 3\n---\n'
+    const result = parseFrontmatter(md, EMPTY_SCHEMA)
+    expect(result.fields.map((f) => f.order)).toEqual([0, 1, 2])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// serializeFrontmatter
+// ---------------------------------------------------------------------------
+
+describe('serializeFrontmatter', () => {
+  it('returns empty string for empty fields array', () => {
+    expect(serializeFrontmatter([])).toBe('')
+  })
+
+  it('serializes a plain text field', () => {
+    const fields: FrontmatterField[] = [{ key: 'title', value: 'My Note', type: 'text', order: 0, styleHint: 'plain' }]
+    expect(serializeFrontmatter(fields)).toBe('title: My Note')
+  })
+
+  it('serializes a boolean field', () => {
+    const fields: FrontmatterField[] = [{ key: 'draft', value: true, type: 'checkbox', order: 0, styleHint: 'plain' }]
+    expect(serializeFrontmatter(fields)).toBe('draft: true')
+  })
+
+  it('serializes a number field', () => {
+    const fields: FrontmatterField[] = [{ key: 'rating', value: 5, type: 'number', order: 0, styleHint: 'plain' }]
+    expect(serializeFrontmatter(fields)).toBe('rating: 5')
+  })
+
+  it('serializes an inline list for tags', () => {
+    const fields: FrontmatterField[] = [{ key: 'tags', value: ['a', 'b'], type: 'tags', order: 0, styleHint: 'inline-list' }]
+    expect(serializeFrontmatter(fields)).toBe('tags: [a, b]')
+  })
+
+  it('serializes a block list', () => {
+    const fields: FrontmatterField[] = [{ key: 'refs', value: ['a.md', 'b.md'], type: 'list', order: 0, styleHint: 'block-list' }]
+    expect(serializeFrontmatter(fields)).toBe('refs:\n  - a.md\n  - b.md')
+  })
+
+  it('serializes an empty list', () => {
+    const fields: FrontmatterField[] = [{ key: 'refs', value: [], type: 'list', order: 0, styleHint: 'block-list' }]
+    expect(serializeFrontmatter(fields)).toBe('refs: []')
+  })
+
+  it('serializes a literal-block string', () => {
+    const fields: FrontmatterField[] = [{ key: 'notes', value: 'line one\nline two', type: 'text', order: 0, styleHint: 'literal-block' }]
+    const result = serializeFrontmatter(fields)
+    expect(result).toContain('notes: |')
+    expect(result).toContain('  line one')
+    expect(result).toContain('  line two')
+  })
+
+  it('sorts fields by order when they are out of sequence', () => {
+    const fields: FrontmatterField[] = [
+      { key: 'b', value: 'second', type: 'text', order: 1, styleHint: 'plain' },
+      { key: 'a', value: 'first', type: 'text', order: 0, styleHint: 'plain' }
+    ]
+    expect(serializeFrontmatter(fields)).toBe('a: first\nb: second')
+  })
+
+  it('quotes values with YAML-significant characters', () => {
+    const fields: FrontmatterField[] = [{ key: 'ref', value: '[[notes/today]]', type: 'text', order: 0, styleHint: 'plain' }]
+    const result = serializeFrontmatter(fields)
+    expect(result).toMatch(/ref: "/)
+  })
+
+  it('does not quote plain ISO date values', () => {
+    const fields: FrontmatterField[] = [{ key: 'due', value: '2025-06-01', type: 'date', order: 0, styleHint: 'plain' }]
+    expect(serializeFrontmatter(fields)).toBe('due: 2025-06-01')
+  })
+
+  it('quotes empty string values', () => {
+    const fields: FrontmatterField[] = [{ key: 'title', value: '', type: 'text', order: 0, styleHint: 'plain' }]
+    expect(serializeFrontmatter(fields)).toBe('title: ""')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// composeMarkdownDocument
+// ---------------------------------------------------------------------------
+
+describe('composeMarkdownDocument', () => {
+  it('wraps body with frontmatter delimiters when yaml is non-empty', () => {
+    const result = composeMarkdownDocument('body text', 'title: My Note')
+    expect(result).toBe('---\ntitle: My Note\n---\nbody text')
+  })
+
+  it('returns just the body when yaml is empty', () => {
+    expect(composeMarkdownDocument('just body', '')).toBe('just body')
+    expect(composeMarkdownDocument('just body', '   ')).toBe('just body')
+  })
+
+  it('strips leading and trailing blank lines from yaml', () => {
+    const result = composeMarkdownDocument('body', '\n\ntitle: A\n\n')
+    expect(result).toBe('---\ntitle: A\n---\nbody')
+  })
+
+  it('normalizes CRLF line endings in body', () => {
+    const result = composeMarkdownDocument('line1\r\nline2', 'title: X')
+    expect(result).toBe('---\ntitle: X\n---\nline1\nline2')
+  })
+})

--- a/src/domains/editor/lib/propertyTypes.test.ts
+++ b/src/domains/editor/lib/propertyTypes.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultPropertyTypeForKey,
+  inferPropertyType,
+  isPropertyType,
+  normalizePropertyKey,
+  resolvePropertyType,
+  sanitizePropertyTypeSchema
+} from './propertyTypes'
+
+describe('normalizePropertyKey', () => {
+  it('lowercases and trims the key', () => {
+    expect(normalizePropertyKey('  Title  ')).toBe('title')
+    expect(normalizePropertyKey('TAGS')).toBe('tags')
+    expect(normalizePropertyKey('created_at')).toBe('created_at')
+  })
+})
+
+describe('inferPropertyType', () => {
+  it('returns checkbox for booleans', () => {
+    expect(inferPropertyType(true)).toBe('checkbox')
+    expect(inferPropertyType(false)).toBe('checkbox')
+  })
+
+  it('returns number for finite numbers', () => {
+    expect(inferPropertyType(42)).toBe('number')
+    expect(inferPropertyType(-3.14)).toBe('number')
+  })
+
+  it('returns text for non-finite numbers', () => {
+    expect(inferPropertyType(Infinity)).toBe('text')
+    expect(inferPropertyType(NaN)).toBe('text')
+  })
+
+  it('returns list for arrays', () => {
+    expect(inferPropertyType([])).toBe('list')
+    expect(inferPropertyType(['a', 'b'])).toBe('list')
+  })
+
+  it('returns date for ISO date-only strings', () => {
+    expect(inferPropertyType('2024-01-15')).toBe('date')
+    expect(inferPropertyType('1999-12-31')).toBe('date')
+  })
+
+  it('returns text for non-date strings', () => {
+    expect(inferPropertyType('hello')).toBe('text')
+    expect(inferPropertyType('2024-01-15T12:00:00')).toBe('text')
+    expect(inferPropertyType('')).toBe('text')
+  })
+})
+
+describe('defaultPropertyTypeForKey', () => {
+  it('returns tags for the "tags" key', () => {
+    expect(defaultPropertyTypeForKey('tags')).toBe('tags')
+    expect(defaultPropertyTypeForKey('TAGS')).toBe('tags')
+  })
+
+  it('returns list for aliases and cssclasses', () => {
+    expect(defaultPropertyTypeForKey('aliases')).toBe('list')
+    expect(defaultPropertyTypeForKey('cssclasses')).toBe('list')
+    expect(defaultPropertyTypeForKey('ALIASES')).toBe('list')
+  })
+
+  it('returns null for unknown keys', () => {
+    expect(defaultPropertyTypeForKey('title')).toBeNull()
+    expect(defaultPropertyTypeForKey('created')).toBeNull()
+  })
+})
+
+describe('resolvePropertyType', () => {
+  it('prefers schema type over inference', () => {
+    const schema = { title: 'text' as const }
+    expect(resolvePropertyType('title', 42, schema)).toBe('text')
+  })
+
+  it('falls back to default key type when not in schema', () => {
+    expect(resolvePropertyType('tags', [], {})).toBe('tags')
+    expect(resolvePropertyType('aliases', [], {})).toBe('list')
+  })
+
+  it('falls back to inferred type when no schema and no default', () => {
+    expect(resolvePropertyType('score', 99, {})).toBe('number')
+    expect(resolvePropertyType('active', true, {})).toBe('checkbox')
+    expect(resolvePropertyType('due', '2025-06-01', {})).toBe('date')
+  })
+})
+
+describe('isPropertyType', () => {
+  it('returns true for all valid property types', () => {
+    const valid = ['text', 'list', 'number', 'checkbox', 'date', 'tags']
+    for (const t of valid) {
+      expect(isPropertyType(t)).toBe(true)
+    }
+  })
+
+  it('returns false for unknown strings', () => {
+    expect(isPropertyType('string')).toBe(false)
+    expect(isPropertyType('boolean')).toBe(false)
+    expect(isPropertyType('')).toBe(false)
+  })
+})
+
+describe('sanitizePropertyTypeSchema', () => {
+  it('normalizes keys and filters to valid types only', () => {
+    const result = sanitizePropertyTypeSchema({
+      Title: 'text',
+      TAGS: 'tags',
+      score: 'number',
+      active: 'checkbox',
+      due: 'date',
+      refs: 'list'
+    })
+    expect(result).toEqual({
+      title: 'text',
+      tags: 'tags',
+      score: 'number',
+      active: 'checkbox',
+      due: 'date',
+      refs: 'list'
+    })
+  })
+
+  it('drops entries with invalid type values', () => {
+    const result = sanitizePropertyTypeSchema({ foo: 'invalid', bar: 'text' })
+    expect(result).toEqual({ bar: 'text' })
+  })
+
+  it('drops entries with non-string keys or values', () => {
+    const result = sanitizePropertyTypeSchema({ 42: 'text', valid: 'number' })
+    // numeric keys become strings in JS objects; key "42" is fine
+    expect(result['valid']).toBe('number')
+  })
+
+  it('returns empty object for null, undefined, and non-objects', () => {
+    expect(sanitizePropertyTypeSchema(null)).toEqual({})
+    expect(sanitizePropertyTypeSchema(undefined)).toEqual({})
+    expect(sanitizePropertyTypeSchema('string')).toEqual({})
+    expect(sanitizePropertyTypeSchema(42)).toEqual({})
+  })
+
+  it('skips empty keys after normalization', () => {
+    const result = sanitizePropertyTypeSchema({ '   ': 'text', normal: 'text' })
+    expect(result).toEqual({ normal: 'text' })
+  })
+})

--- a/src/domains/explorer/lib/explorerTreeUtils.test.ts
+++ b/src/domains/explorer/lib/explorerTreeUtils.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { errorMessage, escapeSelectorValue, getAncestorDirs, getParentPath, isConflictError } from './explorerTreeUtils'
+
+describe('errorMessage', () => {
+  it('returns message from an Error instance', () => {
+    expect(errorMessage(new Error('something went wrong'))).toBe('something went wrong')
+  })
+
+  it('returns a plain string as-is', () => {
+    expect(errorMessage('oops')).toBe('oops')
+  })
+
+  it('returns the message property from an error-like object', () => {
+    expect(errorMessage({ message: 'object error' })).toBe('object error')
+  })
+
+  it('returns null for a non-message object', () => {
+    expect(errorMessage({ code: 42 })).toBeNull()
+  })
+
+  it('returns null for null and undefined', () => {
+    expect(errorMessage(null)).toBeNull()
+    expect(errorMessage(undefined)).toBeNull()
+  })
+
+  it('returns null for a number', () => {
+    expect(errorMessage(404)).toBeNull()
+  })
+})
+
+describe('isConflictError', () => {
+  it('returns true when the error message contains "already exists"', () => {
+    expect(isConflictError(new Error('File already exists at this path'))).toBe(true)
+    expect(isConflictError(new Error('ALREADY EXISTS'))).toBe(true)
+  })
+
+  it('returns false for unrelated errors', () => {
+    expect(isConflictError(new Error('permission denied'))).toBe(false)
+  })
+
+  it('returns false for non-error values', () => {
+    expect(isConflictError(null)).toBe(false)
+    expect(isConflictError(undefined)).toBe(false)
+    expect(isConflictError(42)).toBe(false)
+  })
+})
+
+describe('getParentPath', () => {
+  it('returns the parent directory of a nested path', () => {
+    expect(getParentPath('notes/projects/todo.md')).toBe('notes/projects')
+  })
+
+  it('returns the root segment for a top-level file', () => {
+    expect(getParentPath('notes/todo.md')).toBe('notes')
+  })
+
+  it('returns the original path when there is no parent', () => {
+    // idx <= 0 branch: no slash or slash at position 0
+    expect(getParentPath('todo.md')).toBe('todo.md')
+  })
+
+  it('normalizes backslashes before extracting parent', () => {
+    expect(getParentPath('notes\\projects\\todo.md')).toBe('notes/projects')
+  })
+})
+
+describe('getAncestorDirs', () => {
+  it('returns all ancestor directories between root and a nested path', () => {
+    expect(getAncestorDirs('/vault', '/vault/a/b/note.md')).toEqual([
+      '/vault/a',
+      '/vault/a/b'
+    ])
+  })
+
+  it('returns an empty array when the path is a direct child of root', () => {
+    expect(getAncestorDirs('/vault', '/vault/note.md')).toEqual([])
+  })
+
+  it('returns an empty array when path equals root', () => {
+    expect(getAncestorDirs('/vault', '/vault')).toEqual([])
+  })
+
+  it('returns an empty array when path is outside the root', () => {
+    expect(getAncestorDirs('/vault', '/other/note.md')).toEqual([])
+  })
+})
+
+describe('escapeSelectorValue', () => {
+  it('returns a non-empty string for a simple path', () => {
+    const result = escapeSelectorValue('notes/my-note.md')
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('does not alter a path with no special characters', () => {
+    // Simple alphanumeric path — no characters need escaping
+    expect(escapeSelectorValue('notes/todo')).toBe('notes/todo')
+  })
+
+  it('escapes backslashes in the fallback (non-CSS.escape) path', () => {
+    // When CSS.escape is unavailable the fallback escapes " and \
+    // In the test environment CSS.escape IS available (jsdom), so the
+    // result will be whatever CSS.escape returns — just verify it is a string.
+    const result = escapeSelectorValue('vault\\notes\\today.md')
+    expect(typeof result).toBe('string')
+  })
+})


### PR DESCRIPTION
## Summary

- **`echoes/lib/echoes`** — `toEchoesPack` DTO transform (snake_case → camelCase, edge cases)
- **`explorer/lib/explorerTreeUtils`** — `errorMessage`, `isConflictError`, `getParentPath`, `getAncestorDirs`, `escapeSelectorValue`
- **`editor/lib/propertyTypes`** — `inferPropertyType`, `resolvePropertyType`, `sanitizePropertyTypeSchema`, `defaultPropertyTypeForKey`, `isPropertyType`
- **`editor/lib/frontmatter`** — `parseFrontmatter` (scalars, booleans, numbers, inline/block/literal lists, errors, duplicates, CRLF), `serializeFrontmatter`, `composeMarkdownDocument`

75 new tests, all passing.

## Test plan

- [x] `npx vitest run` on the 4 new test files — all 75 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)